### PR TITLE
Increase size of buffer length variable

### DIFF
--- a/frup.c
+++ b/frup.c
@@ -948,7 +948,7 @@ parse_fru (const void* msgbuf, sd_bus_message* vpdtbl)
   return (rv);
 }
 
-int parse_fru_area (const uint8_t area, const void* msgbuf, const uint8_t len, sd_bus_message* vpdtbl)
+int parse_fru_area (const uint8_t area, const void* msgbuf, const size_t len, sd_bus_message* vpdtbl)
 {
   int ret = 0;
   int rv = -1;

--- a/frup.h
+++ b/frup.h
@@ -10,7 +10,7 @@ extern "C"
 
 /* Parse an IPMI write fru data message into a dictionary containing name value pair of VPD entries.*/
 int parse_fru (const void* msgbuf, sd_bus_message* vpdtbl);
-int parse_fru_area (const uint8_t area, const void* msgbuf, const uint8_t len, sd_bus_message* vpdtbl);
+int parse_fru_area (const uint8_t area, const void* msgbuf, const size_t len, sd_bus_message* vpdtbl);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The latest Barreleye vpd contains additional custom fields in one
of the board sections, pushing the size of the section to over 0x100.

The current variable that stores the buffer size is set to be
uint8_t which doesn't fit the extended size. Changing it to uint32_t.

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/ipmi-fru-parser/15)
<!-- Reviewable:end -->
