### PR TITLE
Support for restricted mode for IPMI commands

### DIFF
--- a/strgfnhandler.C
+++ b/strgfnhandler.C
@@ -99,5 +99,6 @@ ipmi_ret_t ipmi_storage_write_fru_data(ipmi_netfn_t netfn, ipmi_cmd_t cmd,
 void register_netfn_storage_write_fru()
 {
     printf("Registering NetFn:[0x%X], Cmd:[0x%X]\n",NETFUN_STORAGE, IPMI_CMD_WRITE_FRU_DATA);
-    ipmi_register_callback(NETFUN_STORAGE, IPMI_CMD_WRITE_FRU_DATA, NULL, ipmi_storage_write_fru_data);
+    ipmi_register_callback(NETFUN_STORAGE, IPMI_CMD_WRITE_FRU_DATA, NULL, ipmi_storage_write_fru_data,
+                           IPMI_WHITELISTED_COMMAND);   
 }


### PR DESCRIPTION
Only IPMI whitelisted commands are supported in restricted mode. [Storage] Write FRU(0x12) is a whitelisted command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/ipmi-fru-parser/16)
<!-- Reviewable:end -->
