### PR TITLE
Replacing std::ifstream by access(2) for checking file existence

### DIFF
--- a/writefrudata.C
+++ b/writefrudata.C
@@ -663,7 +663,7 @@ int ipmi_validate_fru_area(const uint8_t fruid, const char *fru_file_name,
                          (fruid, get_fru_area_type(fru_entry), bus_type, bmc_fru);
 
         // Physically being present
-        bool present = std::ifstream(fru_file_name);
+        bool present = access(fru_file_name, F_OK) == 0;
         fru_area->set_present(present);
 
         // Only setup dbus path for areas defined in BMC.


### PR DESCRIPTION
Fixes problem reported by issue https://github.com/openbmc/ipmi-fru-parser/issues/12

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/ipmi-fru-parser/17)
<!-- Reviewable:end -->
