### PR TITLE
Handle IOBoard VPD for Barreleye

### DIFF
--- a/argument.C
+++ b/argument.C
@@ -53,6 +53,7 @@ const option ArgumentParser::options[] =
     { "eeprom",   required_argument,  NULL, 'e' },
     { "fruid",    required_argument,  NULL, 'f' },
     { "help",     no_argument,        NULL, 'h' },
+    { "iob",      no_argument,        NULL, 'w' }, // ioboard workaround
     { 0, 0, 0, 0},
 };
 

--- a/fru-area.H
+++ b/fru-area.H
@@ -31,6 +31,9 @@ class ipmi_fru
         // Special bit for BMC readable eeprom only.
         bool iv_bmc_fru;
 
+        // Variable for io board workaround
+        bool iv_iob;
+
         // If a FRU is physically present.
         bool iv_present;
 
@@ -58,7 +61,7 @@ class ipmi_fru
     public:
         // constructor
         ipmi_fru(const uint8_t fruid, const ipmi_fru_area_type type,
-                 sd_bus *bus_type, bool bmc_fru = false);
+                 sd_bus *bus_type, bool bmc_fru = false, bool iob = false);
 
         // Destructor
         virtual ~ipmi_fru();
@@ -85,6 +88,11 @@ class ipmi_fru
         inline bool is_bmc_fru() const
         {
             return iv_bmc_fru;
+        }
+
+        inline bool get_iob() const
+        {
+            return iv_iob;
         }
 
         // returns fru id;

--- a/readeeprom.C
+++ b/readeeprom.C
@@ -17,6 +17,7 @@ static void exit_with_error(const char* err, char** argv)
 int main(int argc, char **argv)
 {
     int rc = 0;
+    bool iob = false;
     uint8_t fruid = 0;
 
     // Handle to per process system bus
@@ -34,7 +35,7 @@ int main(int argc, char **argv)
     }
 
     auto fruid_str = (*cli_options)["fruid"];
-    if (eeprom_file == ArgumentParser::empty_string)
+    if (fruid_str == ArgumentParser::empty_string)
     {
         // User has not passed in the appropriate argument value
         exit_with_error("fruid data not found.", argv);
@@ -46,6 +47,12 @@ int main(int argc, char **argv)
     {
         // User has not passed in the appropriate argument value
         exit_with_error("Invalid fruid.", argv);
+    }
+
+    auto iob_str = (*cli_options)["iob"];
+    if (iob_str == ArgumentParser::true_string)
+    {
+        iob = true;
     }
 
     // Finished getting options out, so release the parser.
@@ -62,7 +69,7 @@ int main(int argc, char **argv)
         // Now that we have the file that contains the eeprom data, go read it and
         // update the Inventory DB.
         bool bmc_fru = true;
-        rc = ipmi_validate_fru_area(fruid, eeprom_file.c_str(), bus_type, bmc_fru);
+        rc = ipmi_validate_fru_area(fruid, eeprom_file.c_str(), bus_type, bmc_fru, iob);
     }
 
     // Cleanup

--- a/writefrudata.H
+++ b/writefrudata.H
@@ -51,7 +51,8 @@ struct common_header
 extern "C" {
 #endif
 
-int ipmi_validate_fru_area(const uint8_t, const char *, sd_bus *, const bool);
+int ipmi_validate_fru_area(const uint8_t, const char *, sd_bus *, const bool,
+                            const bool = false);
 
 #ifdef __cplusplus
 } // extern C


### PR DESCRIPTION
Due to changes to the IOBoard VPD for Barreleye to include the MAC
address, the fru parser needs hardening to handle these changes.
First do not try to read data if the area length is 0. Second
adjust the area length as the checksum is now at a 4 byte
boundary instead of 8. The IOBOARD_WORKAROUND macro will be
added in the barreleye recipe.
Fixes openbmc/ipmi-fru-parser#19

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/ipmi-fru-parser/22)
<!-- Reviewable:end -->
